### PR TITLE
fix monaco Enter issue

### DIFF
--- a/src/hooks/hooksConfig.ts
+++ b/src/hooks/hooksConfig.ts
@@ -1,5 +1,20 @@
 import { Options } from 'react-hotkeys-hook';
 
+const KEYS_TO_IGNORE_WHILE_IN_MONACO = ['Enter'];
+
 export const hotkeysOptions: Options = {
   enableOnTags: ['INPUT', 'TEXTAREA', 'SELECT'],
+  filterPreventDefault: false,
+  filter: (event: KeyboardEvent) => {
+    const target = event?.target as Element;
+    if (
+      // TODO: find a better way to identify that it's being triggered from monaco
+      target?.classList.value.includes('monaco') &&
+      KEYS_TO_IGNORE_WHILE_IN_MONACO.includes(event.code)
+    ) {
+      return false;
+    }
+
+    return true;
+  },
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
- filter keys that should be ignored while typing in `monaco`

`useEnter` triggered in `Wrapper` component conflicts with `monaco` keymaps in production. The long-term solution would be scooping `react-hotkeys-hook`'s hotkeys; [This](https://react-hotkeys-hook.vercel.app/docs/documentation/hotkeys-provider) may be helpful. Short term solution is to identify and prevent certain keys (in this particular case it's only `Enter`) while typing in `monaco`.

- add `vite-env.d.ts` for better, vite-related, typing

To avoid things like this: (I am talking about `@ts-ignore`)

```js
// @ts-ignore
import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
```

which is no more the case, but might use `?worker` or other vite-specific things in the future.
